### PR TITLE
Upgrade to OpenJDK 11 latest minor

### DIFF
--- a/product-write-v1/Dockerfile
+++ b/product-write-v1/Dockerfile
@@ -1,6 +1,4 @@
-FROM adoptopenjdk/openjdk8-openj9:jdk8u162-b12_openj9-0.8.0
-#FROM adoptopenjdk/openjdk9-openj9:jdk-9.181
-#FROM adoptopenjdk/openjdk10-openj9:nightly
+FROM adoptopenjdk/openjdk11-openj9
 
 RUN apt-get update && \
     apt-get dist-upgrade -y && \


### PR DESCRIPTION
Users will almost certainly benefit from updating to the latest LTS major version of Java. This upgrade adds cgroup awareness, an essential feature for preventing OOM kills on a container platform; generally improves performance; and is much less likely to break existing code than the migration from JDK 8 to 9 did.

Always using the latest minor version will ensure users get essential security updates, and there is very little risk of breakage within the same major version.